### PR TITLE
Support multiple limits atomically, support batch increments

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,16 @@ var assert = require("assert");
 var microtime = require("microtime-nodejs");
 
 function RateLimiter (options) {
-  var redis           = options.redis,
-      interval        = options.interval * 1000, // in microseconds
-      maxInInterval   = options.maxInInterval,
-      minDifference   = options.minDifference ? 1000 * options.minDifference : null, // also in microseconds
-      namespace       = options.namespace || (options.redis && ("rate-limiter-" + Math.random().toString(36).slice(2))) || null;
-
-  assert(interval > 0, "Must pass a positive integer for `options.interval`");
-  assert(maxInInterval > 0, "Must pass a positive integer for `options.maxInInterval`");
-  assert(!(minDifference < 0), "`options.minDifference` cannot be negative");
+  var redis = options.redis;
+  var namespace = options.namespace || (options.redis && ("rate-limiter-" + Math.random().toString(36).slice(2))) || null;
+  var limits = [];
+  
+  if (Array.isArray(options.limits)) {
+    assert(options.limits.length, "`options.limits` should not be an empty array");
+    Array.prototype.push.apply(limits, options.limits.map(parseOpts));
+  } else {
+    limits.push(parseOpts(options));
+  }
 
   if (!options.redis) {
     var storage = {};
@@ -38,38 +39,57 @@ function RateLimiter (options) {
         cb = id;
         id = "";
       }
-      
 
       assert.equal(typeof cb, "function", "Callback must be a function.");
       
       var now = microtime.now();
       var key = namespace + id;
-      var clearBefore = now - interval;
-
+      
       var batch = redis.multi();
-      batch.zremrangebyscore(key, 0, clearBefore);
-      batch.zrange(key, 0, -1);
-      batch.zadd(key, now, now);
-      batch.expire(key, Math.ceil(interval / 1000000)); // convert to seconds, as used by redis ttl.
+      
+      var keys = limits.map(function (limit, i) {
+        var interval = limit.interval;
+        var key = namespace + id + (i ? "__" + i : ""); // remain compatible with former versions
+        var clearBefore = now - interval;
+        batch.zremrangebyscore(key, 0, clearBefore);
+        batch.zrange(key, 0, -1);
+        batch.zadd(key, now, now);
+        batch.expire(key, Math.ceil(interval / 1000000)); // convert to seconds, as used by redis ttl.
+        return key;
+      });
+
       batch.exec(function (err, resultArr) {
         if (err) return cb(err);
-    
-        var userSet = zrangeToUserSet(resultArr[1]);
+        
+        var worstMatch = limits.reduce(function (worst, limit, i) {
+          var minDifference = limit.minDifference;
+          var maxInInterval = limit.maxInInterval;
+          var interval = limit.interval;
+          var userSet = zrangeToUserSet(resultArr[i * 4 + 1]);
+          var tooManyInInterval = userSet.length >= maxInInterval;
+          var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
+          
+          var result, remaining;
+          
+          if (tooManyInInterval || timeSinceLastRequest < minDifference) {
+            result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
+            remaining = -1;
+          } else {
+            result = 0;
+            remaining = maxInInterval - userSet.length - 1;
+          }
+          
+          if (!worst || worst.remaining > remaining || worst.result < result ) {
+            return {
+              result: result, 
+              remaining: remaining, 
+              index: i
+            }
+          }
+          return worst;
+        }, undefined)
 
-        var tooManyInInterval = userSet.length >= maxInInterval;
-        var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
-
-        var result, remaining;
-        if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-          result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
-          result = Math.floor(result / 1000); // convert to miliseconds for user readability.
-          remaining = -1;
-        } else {
-          remaining = maxInInterval - userSet.length - 1;
-          result = 0;
-        }
-
-        return cb(null, result, remaining);
+        return cb(null, worstMatch.result / 1000, worstMatch.remaining); // convert from microseconds for user readability.
       });
     };
   } else {
@@ -85,42 +105,68 @@ function RateLimiter (options) {
       }
       
       var now = microtime.now();
-      var clearBefore = now - interval;
-
-      clearTimeout(timeouts[id]);
-      var userSet = storage[id] = (storage[id] || []).filter(function(timestamp) {
-        return timestamp > clearBefore;
-      });
-
-      var tooManyInInterval = userSet.length >= maxInInterval;
-      var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
-
-      var result, remaining;
-      if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-        result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
-        result = Math.floor(result / 1000); // convert from microseconds for user readability.
-        remaining = -1;
-      } else {
-        remaining = maxInInterval - userSet.length - 1;
-        result = 0;
-      }
-      userSet.push(now);
-      timeouts[id] = setTimeout(function() {
-        delete storage[id];
-      }, interval / 1000); // convert to miliseconds for javascript timeout
+      
+      var worstMatch = limits.reduce(function (worst, limit, i) {
+        var minDifference = limit.minDifference;
+        var maxInInterval = limit.maxInInterval;
+        var interval = limit.interval;
+        var key = id + (i ? "__" + i : ""); // remain compatible with former versions
+        clearTimeout(timeouts[key]);
+        var clearBefore = now - interval;
+        var userSet = storage[key] = (storage[key] || []).filter(function(timestamp) {
+          return timestamp > clearBefore;
+        })
+        
+        var tooManyInInterval = userSet.length >= maxInInterval;
+        var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
+        
+        var result, remaining;
+        if (tooManyInInterval || timeSinceLastRequest < minDifference) {
+          result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
+          remaining = -1;
+        } else {
+          remaining = maxInInterval - userSet.length - 1;
+          result = 0;
+        }
+        
+        userSet.push(now);
+        timeouts[key] = setTimeout(function () {
+          delete storage[key];
+        }, interval / 1000); // convert to milliseconds for javascript timeout
+        
+        if (!worst || worst.remaining > remaining || worst.result < result ) {
+          return {
+            result: result, 
+            remaining: remaining, 
+            index: i
+          }
+        }
+        return worst;
+      }, undefined);
+      
+      worstMatch.result = worstMatch.result / 1000 // convert from microseconds for user readability.
 
       if (cb) {
         return process.nextTick(function() {
-          cb(null, result, remaining);
+          cb(null, worstMatch.result, worstMatch.remaining); 
         });
       } else {
-        return result;
+        return worstMatch.result;
       }
     };
   }
 }
 
+function parseOpts (options) {
+  var config = {
+    interval:       options.interval * 1000, // in microseconds
+    maxInInterval:  options.maxInInterval,
+    minDifference:  options.minDifference ? 1000 * options.minDifference : null, // also in microseconds
+  };
+  assert(config.interval > 0, "Must pass a positive integer for `options.interval`");
+  assert(config.maxInInterval > 0, "Must pass a positive integer for `options.maxInInterval`");
+  assert(!(config.minDifference < 0), "`options.minDifference` cannot be negative");
+  return config;
+}
+
 module.exports = RateLimiter;
-
-
-

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "microtime-nodejs": "~1.0.0"
   },
   "devDependencies": {
-    "fakeredis": "~0.3.0",
-    "chai": "~1.10.0",
     "async": "~0.9.0",
+    "chai": "~1.10.0",
+    "fakeredis": "~0.3.0",
     "mocha": "~2.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,6 @@ describe("rateLimiter", function () {
       expect(counter.getCount(2)).to.equal(30);
     });
 
-
     it("allows requests after the interval has passed", function(done) {
       var counter = RateLimitedCounter({
         interval: 100,

--- a/test/index.js
+++ b/test/index.js
@@ -422,7 +422,6 @@ describe("rateLimiter", function () {
       });
     });
 
-
     it("allows requests after the interval has passed", function(done) {
       var counter = RateLimitedCounter({
         redis: redis.createClient(),


### PR DESCRIPTION
- [x] Add support for multiple limits, maintained atomically in Redis. 96a2967
- [x] Remove negative timeLefts 77f37f2
- [ ] Add support for incrementing by a number greater than one

The API now accepts an array of limits additonally to the previously accepted input:
```js
var rateLimiter = require('rolling-rate-limiter')
var limiter = rateLimiter(options: {
  redis?: Redis,
  namespace?: string,
  limits: { interval: number, maxInInterval: number, minDifference?: number }[]
});
```
We maintain a redis key for each of the limits. The keys are derived the following way:
```
  first limit: 
    key = namespace + id \\ to remain backward compatible
  rest of the limits:
    key = namespace + id + "__" + index
```
Because we cannot be sure that te key `mynamespacemyid__i`, doesn't exist yet, a minimal chance of collision with existing keys may occur.

The callback returns `timeLeft` as the maximum of cooldown periods, `actionsLeft` as the minimum actions left.

Existing behavior is unaffected.