### PR TITLE
Fix timeLeft Parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+.idea/

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function RateLimiter (options) {
 
         var result, remaining;
         if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-          result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? timeSinceLastRequest + minDifference : 0);
+          result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? minDifference : 0);
           result = Math.floor(result / 1000); // convert to miliseconds for user readability.
           remaining = -1;
         } else {
@@ -97,7 +97,7 @@ function RateLimiter (options) {
 
       var result, remaining;
       if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-        result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? timeSinceLastRequest + minDifference : 0);
+        result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? minDifference : 0);
         result = Math.floor(result / 1000); // convert from microseconds for user readability.
         remaining = -1;
       } else {

--- a/index.js
+++ b/index.js
@@ -57,11 +57,11 @@ function RateLimiter (options) {
         var userSet = zrangeToUserSet(resultArr[1]);
 
         var tooManyInInterval = userSet.length >= maxInInterval;
-        var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
+        var timeSinceLastRequest = now - userSet[userSet.length - 1];
 
         var result, remaining;
         if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-          result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
+          result = Math.max(userSet[userSet.length - maxInInterval] - now + interval, minDifference ? timeSinceLastRequest + minDifference : 0);
           result = Math.floor(result / 1000); // convert to miliseconds for user readability.
           remaining = -1;
         } else {
@@ -93,11 +93,11 @@ function RateLimiter (options) {
       });
 
       var tooManyInInterval = userSet.length >= maxInInterval;
-      var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
+      var timeSinceLastRequest = now - userSet[userSet.length - 1];
 
       var result, remaining;
       if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-        result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
+        result = Math.max(userSet[userSet.length - maxInInterval] - now + interval, minDifference ? timeSinceLastRequest + minDifference : 0);
         result = Math.floor(result / 1000); // convert from microseconds for user readability.
         remaining = -1;
       } else {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function RateLimiter (options) {
 
         var result, remaining;
         if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-          result = Math.max(userSet[userSet.length - maxInInterval] - now + interval, minDifference ? timeSinceLastRequest + minDifference : 0);
+          result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? timeSinceLastRequest + minDifference : 0);
           result = Math.floor(result / 1000); // convert to miliseconds for user readability.
           remaining = -1;
         } else {
@@ -97,7 +97,7 @@ function RateLimiter (options) {
 
       var result, remaining;
       if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-        result = Math.max(userSet[userSet.length - maxInInterval] - now + interval, minDifference ? timeSinceLastRequest + minDifference : 0);
+        result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? timeSinceLastRequest + minDifference : 0);
         result = Math.floor(result / 1000); // convert from microseconds for user readability.
         remaining = -1;
       } else {


### PR DESCRIPTION
This PullRequest fixes the calculation of the `timeLeft` value.

The former calculation had the following two issues:

1. If requests were sent after the `maxInInterval` limit had already been exceeded the `timeLeft` value was still beeing calculated with the first request in the interval.
2. If `minDifference` was specified, the `timeLeft` value could get negative values. See #14.