### PR TITLE
Changes return value of remaining parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+.idea/

--- a/index.js
+++ b/index.js
@@ -59,13 +59,13 @@ function RateLimiter (options) {
         var tooManyInInterval = userSet.length >= maxInInterval;
         var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
 
-        var result, remaining;
+        var result;
+        var remaining = maxInInterval - userSet.length - 1;
+		
         if (tooManyInInterval || timeSinceLastRequest < minDifference) {
           result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
           result = Math.floor(result / 1000); // convert to miliseconds for user readability.
-          remaining = -1;
         } else {
-          remaining = maxInInterval - userSet.length - 1;
           result = 0;
         }
 
@@ -95,13 +95,13 @@ function RateLimiter (options) {
       var tooManyInInterval = userSet.length >= maxInInterval;
       var timeSinceLastRequest = minDifference && (now - userSet[userSet.length - 1]);
 
-      var result, remaining;
+      var result;
+      var remaining = maxInInterval - userSet.length - 1;
+      
       if (tooManyInInterval || timeSinceLastRequest < minDifference) {
         result = Math.min(userSet[0] - now + interval, minDifference ? minDifference - timeSinceLastRequest : Infinity);
         result = Math.floor(result / 1000); // convert from microseconds for user readability.
-        remaining = -1;
       } else {
-        remaining = maxInInterval - userSet.length - 1;
         result = 0;
       }
       userSet.push(now);


### PR DESCRIPTION
This PullRequest changes the calculation of the `remaining` value to allow negative values below -1.

Until now the `remaining` value would always return -1 if the request was blocked.
If requests are sent after the `maxInInterval` limit has already been exceeded those blocked requests are also applied to the set, but the remaining value would stay at -1.

I would have expected the value to change according to the following example.
If a user of this library does not want to give this information to their users, they could still return -1.

Example:
```
interval: 10000
maxInInterval: 4

t0: Action permitted (remaining: 3)
t1: Action permitted (remaining: 2)
t2: Action permitted (remaining: 1)
t3: Action permitted (remaining: 0)
t4: Action blocked (remaining: -1)
t5: Action blocked (remaining: -2)
etc...
```