### PR TITLE
Increase wait time for each backlogged interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,14 @@ function RateLimiter (options) {
 
         var userSet = zrangeToUserSet(resultArr[1]);
 
-        var tooManyInInterval = userSet.length >= maxInInterval;
+        var backloggedIntervals = parseInt(userSet.length / maxInInterval, 10);
         var timeSinceLastRequest = now - userSet[userSet.length - 1];
 
         var result;
         var remaining = maxInInterval - userSet.length - 1;
 
-        if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-          result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? minDifference : 0);
+        if (backloggedIntervals > 0 || timeSinceLastRequest < minDifference) {
+          result = Math.max(backloggedIntervals > 0 ? userSet[userSet.length - maxInInterval] - now + interval * backloggedIntervals : 0, minDifference ? minDifference : 0);
           result = Math.floor(result / 1000); // convert to miliseconds for user readability.
         } else {
           result = 0;
@@ -94,14 +94,14 @@ function RateLimiter (options) {
         return timestamp > clearBefore;
       });
 
-      var tooManyInInterval = userSet.length >= maxInInterval;
+      var backloggedIntervals = parseInt(userSet.length / maxInInterval, 10);
       var timeSinceLastRequest = now - userSet[userSet.length - 1];
 
       var result;
       var remaining = maxInInterval - userSet.length - 1;
 
-      if (tooManyInInterval || timeSinceLastRequest < minDifference) {
-        result = Math.max(tooManyInInterval ? userSet[userSet.length - maxInInterval] - now + interval : 0, minDifference ? minDifference : 0);
+      if (backloggedIntervals > 0 || timeSinceLastRequest < minDifference) {
+        result = Math.max(backloggedIntervals > 0 ? userSet[userSet.length - maxInInterval] - now + interval * backloggedIntervals : 0, minDifference ? minDifference : 0);
         result = Math.floor(result / 1000); // convert from microseconds for user readability.
       } else {
         result = 0;

--- a/test/index.js
+++ b/test/index.js
@@ -171,11 +171,20 @@ describe("rateLimiter", function() {
       var first = limiter1();
       var second = limiter1();
       var third = limiter1();
+      var fourth = limiter1();
+      var fifth = limiter1();
+      var sixth = limiter1();
 
       expect(first).to.equal(0);
       expect(second).to.equal(0);
       expect(third).to.be.above(9900);
       expect(third).to.be.below(10001);
+      expect(fourth).to.be.above(9900);
+      expect(fourth).to.be.below(10001);
+      expect(fifth).to.be.above(19900);
+      expect(fifth).to.be.below(20001);
+      expect(sixth).to.be.above(19900);
+      expect(sixth).to.be.below(20001);
 
       var limiter2 = RateLimiter({
         interval: 10000,
@@ -456,13 +465,19 @@ describe("rateLimiter", function() {
         interval: 10000,
         maxInInterval: 2,
       });
-      async.times(3, function(n, next) {
+      async.times(6, function(n, next) {
         limiter1(next);
       }, function(err, results) {
         expect(results[0]).to.equal(0);
         expect(results[1]).to.equal(0);
         expect(results[2]).to.be.above(9900);
         expect(results[2]).to.be.below(10001);
+        expect(results[3]).to.be.above(9900);
+        expect(results[3]).to.be.below(10001);
+        expect(results[4]).to.be.above(19900);
+        expect(results[4]).to.be.below(20001);
+        expect(results[5]).to.be.above(19900);
+        expect(results[5]).to.be.below(20001);
 
         // ---
 


### PR DESCRIPTION
The wait time needs to increase for each batch that is pending, rather than just returning the same amount for every operation past the “too-many” mark.

Consider a rate limiter that allows 2 operations per 5 seconds. Before this change:

```
0
0
5000
5000
5000
5000
5000
5000
```
After:
```
0
0
5000
5000
10000
10000
15000
15000
```