### PR TITLE
Avoid timestamp collisions by storing UUID as value in set

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/classdojo/rolling-rate-limiter",
   "dependencies": {
-    "microtime-nodejs": "~1.0.0"
+    "microtime-nodejs": "~1.0.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
If multiple events happen at the same time, only one will be stored (since it’s a set) and the results will be incorrect. Using a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) as the value stored in the set effectively prevents this.