### PR TITLE
ioredis compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,13 @@ function RateLimiter (options) {
       batch.exec(function(err, resultArr) {
         if (err) return cb(err);
 
-        var userSet = zrangeToUserSet(resultArr[1]).filter(function(elem, i) {
+        var zrangeResult = resultArr[1];
+        // If the result of zrange is an array ([err, result]), then use the second element.
+        if (Array.isArray(zrangeResult)) {
+          zrangeResult = zrangeResult[1];
+        }
+        
+        var userSet = zrangeToUserSet(zrangeResult).filter(function(elem, i) {
           return i % 2 != 0;
         });
 

--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ function RateLimiter (options) {
         if (err) return cb(err);
 
         var zrangeResult = resultArr[1];
-        // If the result of zrange is an array ([err, result]), then use the second element.
-        if (Array.isArray(zrangeResult)) {
+        // If the second element of the ZRANGE result is an array, then use it as the result. This is how ioredis formats the result ([err, [result]])
+        if (Array.isArray(zrangeResult[1])) {
           zrangeResult = zrangeResult[1];
         }
         


### PR DESCRIPTION
The result of `redis.multi()` with ioredis is [different](https://github.com/luin/ioredis/wiki/Migrating-from-node_redis) from node_redis which is what I assume this package was developed with. Currently ioredis causes this package to silently fail as requests are never rate limited. This pull request checks the format of the ZRANGE result so it now works with node_redis and ioredis.